### PR TITLE
refactor: simplify global styles and layout

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,25 +4,25 @@ import { siteConfig } from "@/config/site";
 
 export default function Footer() {
   return (
-    <footer className="mt-10 w-full border-t border-custom-medium-green/30 bg-custom-dark-green/95 py-6 text-custom-cream">
-      <div className="mx-auto flex max-w-7xl flex-col items-center gap-2 px-6">
+    <footer className="mt-10 w-full border-t border-custom-dark-green/10 bg-custom-cream py-6 text-custom-black">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-2 px-6">
         <Link
           isExternal
-          className="flex items-center gap-2 rounded-xl px-2 py-1 text-current transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-light-green"
+          className="flex items-center gap-2 rounded-xl px-2 py-1 text-current transition hover:text-custom-dark-green focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-medium-green"
           href="https://heroui.com?utm_source=next-app-template"
           title="heroui.com homepage"
         >
           <span>Powered by</span>
-          <p className="font-semibold text-custom-light-green">Autóctonos</p>
+          <p className="font-semibold text-custom-dark-green">Autóctonos</p>
         </Link>
         <div className="flex items-center gap-3">
           <Link
             isExternal
             aria-label="Twitter"
             href={siteConfig.links.twitter}
-            className="rounded-full p-1 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-light-green"
+            className="rounded-full p-1 transition hover:text-custom-dark-green focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-custom-medium-green"
           >
-            <TwitterIcon className="text-custom-light-green" />
+            <TwitterIcon className="text-custom-dark-green" />
           </Link>
         </div>
       </div>

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -12,25 +12,21 @@ export default function HomeClient() {
 
   return (
     <>
-      <section className="flex flex-col items-center justify-center gap-5 py-8 md:py-10">
-        <img src="/logo.svg" alt="logo" height={300} width={300} />
-        <div className="inline-block max-w-xl justify-center text-center">
-          <span className={title()}>Compra y vende&nbsp;</span>
-          <span className={title({ color: "pink" })}>productos&nbsp;</span>
-          <br />
-          <span className={title()}>artesanales locales</span>
-          <div className={subtitle({ class: "mt-4" })}>
-            El marketplace donde la tradición y la calidad se encuentran
-          </div>
-        </div>
+      <section className="flex flex-col items-center justify-center gap-6 py-24 text-center">
+        <h1 className={title()}>
+          Compra y vende <span className="text-custom-dark-green">productos</span> artesanales locales
+        </h1>
+        <p className={subtitle({ class: "mt-4 max-w-2xl" })}>
+          El marketplace donde la tradición y la calidad se encuentran
+        </p>
       </section>
 
       <section className="container mx-auto px-4 py-6">
         <h2 className={subtitle({ class: "mb-4 text-xl font-semibold" })}>Productos Destacados</h2>
         {prod.loading ? (
-          <div className="flex items-center gap-2 text-gray-600"><Spinner size="sm" /> Cargando productos…</div>
+          <div className="flex items-center gap-2 text-custom-black/60"><Spinner size="sm" /> Cargando productos…</div>
         ) : prod.error ? (
-          <p className="text-red-600">{prod.error}</p>
+          <p className="text-custom-red">{prod.error}</p>
         ) : (
           <ProductsList products={prod.data ?? []} />
         )}
@@ -39,9 +35,9 @@ export default function HomeClient() {
       <section className="container mx-auto px-4 py-6">
         <h2 className={subtitle({ class: "mb-4 text-xl font-semibold" })}>Categorías</h2>
         {cats.loading ? (
-          <div className="flex items-center gap-2 text-gray-600"><Spinner size="sm" /> Cargando categorías…</div>
+          <div className="flex items-center gap-2 text-custom-black/60"><Spinner size="sm" /> Cargando categorías…</div>
         ) : cats.error ? (
-          <p className="text-red-600">{cats.error}</p>
+          <p className="text-custom-red">{cats.error}</p>
         ) : (
           <CategoryList categories={cats.data ?? []} />
         )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ export default function Navbar() {
     <HeroUINavbar
       maxWidth="xl"
       position="sticky"
-      className="sticky top-0 z-50 border-b border-custom-medium-green/30 bg-custom-cream/80 backdrop-blur-md supports-[backdrop-filter]:bg-custom-cream/60"
+      className="sticky top-0 z-50 border-b border-custom-dark-green/10 bg-custom-cream/90 backdrop-blur-sm"
     >
 
       <NavbarContent className="basis-1/4 sm:basis-full" justify="start">
@@ -107,9 +107,9 @@ export default function Navbar() {
             />
 
             {openList && (loading || results.length > 0) && (
-              <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-2xl border border-custom-medium-green/30 bg-white shadow-xl">
+              <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-2xl border border-custom-medium-green/30 bg-custom-cream shadow-xl">
                 {loading ? (
-                  <div className="flex items-center gap-2 p-3 text-sm text-gray-600">
+                    <div className="flex items-center gap-2 p-3 text-sm text-custom-black/60">
                     <Spinner size="sm" /> Buscando…
                   </div>
                 ) : (
@@ -166,7 +166,7 @@ export default function Navbar() {
 
 
       {/* Menú hamburguesa */}
-      <NavbarMenu className="bg-custom-cream/95 p-3">
+      <NavbarMenu className="bg-custom-cream p-3">
         <div className="mb-3">
           <div className="relative">
             <Input
@@ -187,9 +187,9 @@ export default function Navbar() {
               type="search"
             />
             {(loading || results.length > 0) && query && (
-              <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-2xl border border-custom-medium-green/30 bg-white shadow-xl">
+              <div className="absolute left-0 top-full z-50 mt-1 w-full overflow-hidden rounded-2xl border border-custom-medium-green/30 bg-custom-cream shadow-xl">
                 {loading ? (
-                  <div className="flex items-center gap-2 p-3 text-sm text-gray-600">
+                    <div className="flex items-center gap-2 p-3 text-sm text-custom-black/60">
                     <Spinner size="sm" /> Buscando…
                   </div>
                 ) : (

--- a/src/components/primitives.ts
+++ b/src/components/primitives.ts
@@ -1,19 +1,19 @@
-type Opt = { class?: string; color?: "pink" | "green" };
+type Opt = { class?: string; color?: "red" | "green" };
 
 export function title(opt: Opt = {}) {
   const base = "font-extrabold tracking-tight";
-  const size = "text-3xl md:text-5xl";
+  const size = "text-4xl md:text-6xl";
   const color =
-    opt.color === "pink"
-      ? "text-pink-600"
+    opt.color === "red"
+      ? "text-custom-red"
       : opt.color === "green"
       ? "text-custom-dark-green"
-      : "text-custom-dark-green";
+      : "text-custom-black";
   return [base, size, color, opt.class].filter(Boolean).join(" ");
 }
 
 export function subtitle(opt: Opt = {}) {
-  const base = "text-base md:text-lg";
-  const color = "text-custom-black/80";
+  const base = "text-lg md:text-xl";
+  const color = "text-custom-black/70";
   return [base, color, opt.class].filter(Boolean).join(" ");
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,8 +11,8 @@ import CartDrawer from "@/components/cart-drawer";
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
   </head>
-  <body class="relative flex min-h-screen flex-col bg-custom-cream">
-    <main class="container mx-auto max-w-7xl flex-grow px-6 pt-16">
+  <body class="flex min-h-screen flex-col">
+    <main class="mx-auto w-full max-w-6xl flex-grow px-6 py-24">
       <slot />
       <CartDrawer client:load />
     </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,38 @@
   --color-custom-light-green: #A7C957;
   --color-custom-red: #BC4749;
   --color-custom-black: #111111;
+  --font-sans: "Inter", system-ui, sans-serif;
 }
 
+@layer base {
+  html {
+    font-family: var(--font-sans);
+    background-color: var(--color-custom-cream);
+    color: var(--color-custom-black);
+    @apply antialiased;
+  }
 
-.ui-icon { width: 1.125rem; height: 1.125rem; display:inline-block; vertical-align:middle; }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-extrabold tracking-tight text-custom-dark-green;
+  }
+
+  a {
+    @apply text-custom-dark-green underline-offset-2 transition-colors;
+  }
+
+  a:hover {
+    @apply text-custom-medium-green;
+  }
+}
+
+.ui-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  display: inline-block;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Summary
- simplify global theme with Inter font, global colors, and base element styles
- streamline layout and footer for minimal appearance
- restyle home hero and navigation to use global color palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f701782b08331aa1f8860c1cd53ae